### PR TITLE
Implement Minerware custom events

### DIFF
--- a/src/LatamPMDevs/minerware/arena/microgame/Microgame.php
+++ b/src/LatamPMDevs/minerware/arena/microgame/Microgame.php
@@ -23,10 +23,10 @@ declare(strict_types=1);
 namespace LatamPMDevs\minerware\arena\microgame;
 
 use LatamPMDevs\minerware\arena\Arena;
-use LatamPMDevs\minerware\event\microgame\MicrogameEndEvent;
-use LatamPMDevs\minerware\event\microgame\MicrogameStartEvent;
-use LatamPMDevs\minerware\event\microgame\PlayerMicrogameLoseEvent;
-use LatamPMDevs\minerware\event\microgame\PlayerMicrogameWinEvent;
+use LatamPMDevs\minerware\event\arena\microgame\MicrogameEndEvent;
+use LatamPMDevs\minerware\event\arena\microgame\MicrogameStartEvent;
+use LatamPMDevs\minerware\event\arena\microgame\PlayerMicrogameLoseEvent;
+use LatamPMDevs\minerware\event\arena\microgame\PlayerMicrogameWinEvent;
 use LatamPMDevs\minerware\Minerware;
 
 use pocketmine\player\Player;

--- a/src/LatamPMDevs/minerware/arena/microgame/boss/ColorFloor.php
+++ b/src/LatamPMDevs/minerware/arena/microgame/boss/ColorFloor.php
@@ -53,7 +53,6 @@ use function array_reverse;
 use function array_slice;
 use function asort;
 use function count;
-use function microtime;
 use function shuffle;
 
 class ColorFloor extends Microgame implements Listener {
@@ -93,8 +92,6 @@ class ColorFloor extends Microgame implements Listener {
 	}
 
 	public function start() : void {
-		$this->startTime = microtime(true);
-		$this->hasStarted = true;
 		$this->plugin->getServer()->getPluginManager()->registerEvents($this, $this->plugin);
 
 		$map = $this->arena->getMap();
@@ -140,6 +137,7 @@ class ColorFloor extends Microgame implements Listener {
 		if (!$this->arena->areInvisibleBlocksSet()) {
 			$this->arena->buildInvisibleBlocks();
 		}
+		parent::start();
 	}
 
 	public function tick() : void {
@@ -169,7 +167,6 @@ class ColorFloor extends Microgame implements Listener {
 	}
 
 	public function end() : void {
-		$this->hasEnded = true;
 		HandlerListManager::global()->unregisterAll($this);
 
 		$players = $this->arena->getPlayers();
@@ -207,6 +204,7 @@ class ColorFloor extends Microgame implements Listener {
 		foreach ($this->changedBlocks as $block) {
 			$this->arena->getWorld()->setBlock($block->getPosition(), $block, false);
 		}
+		parent::end();
 	}
 
 	public function setAssignedColor(Player $player, DyeColor $color) : void {

--- a/src/LatamPMDevs/minerware/arena/microgame/normal/IgniteTNT.php
+++ b/src/LatamPMDevs/minerware/arena/microgame/normal/IgniteTNT.php
@@ -46,7 +46,6 @@ use pocketmine\utils\AssumptionFailedError;
 use function array_rand;
 use function array_reverse;
 use function asort;
-use function microtime;
 
 class IgniteTNT extends Microgame implements Listener {
 
@@ -75,8 +74,6 @@ class IgniteTNT extends Microgame implements Listener {
 	}
 
 	public function start() : void {
-		$this->startTime = microtime(true);
-		$this->hasStarted = true;
 		$this->plugin->getServer()->getPluginManager()->registerEvents($this, $this->plugin);
 
 		$map = $this->arena->getMap();
@@ -98,6 +95,7 @@ class IgniteTNT extends Microgame implements Listener {
 		}
 		$this->arena->buildWinnersCage();
 		$this->arena->buildLosersCage();
+		parent::start();
 	}
 
 	public function tick() : void {
@@ -117,7 +115,6 @@ class IgniteTNT extends Microgame implements Listener {
 	}
 
 	public function end() : void {
-		$this->hasEnded = true;
 		HandlerListManager::global()->unregisterAll($this);
 
 		$players = $this->arena->getPlayers();
@@ -136,6 +133,7 @@ class IgniteTNT extends Microgame implements Listener {
 		foreach ($this->changedBlocks as $block) {
 			$this->arena->getWorld()->setBlock($block->getPosition(), $block, false);
 		}
+		parent::end();
 	}
 
 	public function getIgnitedTNTs(Player $player) : int {

--- a/src/LatamPMDevs/minerware/arena/microgame/normal/LastKnightStanding.php
+++ b/src/LatamPMDevs/minerware/arena/microgame/normal/LastKnightStanding.php
@@ -41,7 +41,6 @@ use pocketmine\utils\AssumptionFailedError;
 use function array_key_first;
 use function array_reverse;
 use function asort;
-use function microtime;
 
 class LastKnightStanding extends Microgame implements Listener {
 
@@ -67,8 +66,6 @@ class LastKnightStanding extends Microgame implements Listener {
 	}
 
 	public function start() : void {
-		$this->startTime = microtime(true);
-		$this->hasStarted = true;
 		$this->plugin->getServer()->getPluginManager()->registerEvents($this, $this->plugin);
 
 		$helmet = VanillaItems::IRON_HELMET();
@@ -91,6 +88,7 @@ class LastKnightStanding extends Microgame implements Listener {
 		}
 		$this->arena->buildWinnersCage();
 		$this->arena->buildLosersCage();
+		parent::start();
 	}
 
 	public function tick() : void {
@@ -110,7 +108,6 @@ class LastKnightStanding extends Microgame implements Listener {
 	}
 
 	public function end() : void {
-		$this->hasEnded = true;
 		HandlerListManager::global()->unregisterAll($this);
 
 		$players = $this->arena->getPlayers();
@@ -134,6 +131,7 @@ class LastKnightStanding extends Microgame implements Listener {
 				$player->sendMessage($this->plugin->getTranslator()->translate($player, "microgame.lastknightstanding.lose"));
 			}
 		}
+		parent::end();
 	}
 
 	public function getKills(Player $player) : int {

--- a/src/LatamPMDevs/minerware/arena/microgame/normal/MineOre.php
+++ b/src/LatamPMDevs/minerware/arena/microgame/normal/MineOre.php
@@ -40,7 +40,6 @@ use pocketmine\player\GameMode;
 use pocketmine\player\Player;
 use pocketmine\world\format\Chunk;
 use function array_rand;
-use function microtime;
 use function mt_rand;
 use function str_replace;
 use function strtolower;
@@ -86,8 +85,6 @@ class MineOre extends Microgame implements Listener {
 
 	public function start() : void {
 		$ores = self::getOres();
-		$this->startTime = microtime(true);
-		$this->hasStarted = true;
 		$this->plugin->getServer()->getPluginManager()->registerEvents($this, $this->plugin);
 		$oreKey = array_rand($ores);
 		$this->ore = $ores[$oreKey];
@@ -134,6 +131,7 @@ class MineOre extends Microgame implements Listener {
 		}
 		$this->arena->buildWinnersCage();
 		$this->arena->buildLosersCage();
+		parent::start();
 	}
 
 	public function tick() : void {
@@ -153,7 +151,6 @@ class MineOre extends Microgame implements Listener {
 	}
 
 	public function end() : void {
-		$this->hasEnded = true;
 		HandlerListManager::global()->unregisterAll($this);
 
 		$miner = null;
@@ -193,6 +190,7 @@ class MineOre extends Microgame implements Listener {
 		foreach ($this->changedBlocks as $block) {
 			$this->arena->getWorld()->setBlock($block->getPosition(), $block, false);
 		}
+		parent::end();
 	}
 
 	public function getMinedBlocks(Player $player) : int {

--- a/src/LatamPMDevs/minerware/arena/microgame/normal/Sneaking.php
+++ b/src/LatamPMDevs/minerware/arena/microgame/normal/Sneaking.php
@@ -83,6 +83,7 @@ class Sneaking extends Microgame implements Listener {
 		}
 		$this->arena->buildWinnersCage();
 		$this->arena->buildLosersCage();
+		parent::start();
 	}
 
 	public function tick() : void {
@@ -106,7 +107,6 @@ class Sneaking extends Microgame implements Listener {
 				$this->arena->sendToLosersCage($player);
 			}
 		}
-		parent::start();
 	}
 
 	public function end() : void {

--- a/src/LatamPMDevs/minerware/arena/microgame/normal/Sneaking.php
+++ b/src/LatamPMDevs/minerware/arena/microgame/normal/Sneaking.php
@@ -38,7 +38,6 @@ use pocketmine\event\player\PlayerMoveEvent;
 use pocketmine\event\player\PlayerToggleSneakEvent;
 use pocketmine\player\GameMode;
 use pocketmine\player\Player;
-use function microtime;
 
 class Sneaking extends Microgame implements Listener {
 
@@ -64,8 +63,6 @@ class Sneaking extends Microgame implements Listener {
 	}
 
 	public function start() : void {
-		$this->startTime = microtime(true);
-		$this->hasStarted = true;
 		$this->plugin->getServer()->getPluginManager()->registerEvents($this, $this->plugin);
 
 		$map = $this->arena->getMap();
@@ -109,10 +106,10 @@ class Sneaking extends Microgame implements Listener {
 				$this->arena->sendToLosersCage($player);
 			}
 		}
+		parent::start();
 	}
 
 	public function end() : void {
-		$this->hasEnded = true;
 		HandlerListManager::global()->unregisterAll($this);
 
 		$players = $this->arena->getPlayers();
@@ -131,6 +128,7 @@ class Sneaking extends Microgame implements Listener {
 		foreach ($this->changedBlocks as $block) {
 			$this->arena->getWorld()->setBlock($block->getPosition(), $block, false);
 		}
+		parent::end();
 	}
 
 	public function getTotalSneakedDistance() : float {

--- a/src/LatamPMDevs/minerware/arena/microgame/normal/StackBlocks.php
+++ b/src/LatamPMDevs/minerware/arena/microgame/normal/StackBlocks.php
@@ -41,7 +41,6 @@ use function array_key_first;
 use function array_reverse;
 use function asort;
 use function count;
-use function microtime;
 use function shuffle;
 
 class StackBlocks extends Microgame implements Listener {
@@ -74,8 +73,6 @@ class StackBlocks extends Microgame implements Listener {
 	}
 
 	public function start() : void {
-		$this->startTime = microtime(true);
-		$this->hasStarted = true;
 		$this->plugin->getServer()->getPluginManager()->registerEvents($this, $this->plugin);
 		$dyeColors = DyeColor::getAll();
 		shuffle($dyeColors);
@@ -94,6 +91,7 @@ class StackBlocks extends Microgame implements Listener {
 		if (!$this->arena->areInvisibleBlocksSet()) {
 			$this->arena->buildInvisibleBlocks();
 		}
+		parent::start();
 	}
 
 	public function tick() : void {
@@ -113,7 +111,6 @@ class StackBlocks extends Microgame implements Listener {
 	}
 
 	public function end() : void {
-		$this->hasEnded = true;
 		HandlerListManager::global()->unregisterAll($this);
 
 		$players = $this->arena->getPlayers();
@@ -148,6 +145,7 @@ class StackBlocks extends Microgame implements Listener {
 		foreach ($this->changedBlocks as $block) {
 			$this->arena->getWorld()->setBlock($block->getPosition(), $block, false);
 		}
+		parent::end();
 	}
 
 	public function getAssignedBlock(Player $player) : ?Block {

--- a/src/LatamPMDevs/minerware/arena/microgame/normal/StandOnColor.php
+++ b/src/LatamPMDevs/minerware/arena/microgame/normal/StandOnColor.php
@@ -48,7 +48,6 @@ use function array_key_first;
 use function array_rand;
 use function array_reverse;
 use function asort;
-use function microtime;
 
 class StandOnColor extends Microgame implements Listener {
 
@@ -87,8 +86,6 @@ class StandOnColor extends Microgame implements Listener {
 
 	public function start() : void {
 		$colors = self::getColors();
-		$this->startTime = microtime(true);
-		$this->hasStarted = true;
 		$this->plugin->getServer()->getPluginManager()->registerEvents($this, $this->plugin);
 		$this->color = $colors[array_rand($colors)];
 
@@ -126,6 +123,7 @@ class StandOnColor extends Microgame implements Listener {
 		}
 		$this->arena->buildWinnersCage();
 		$this->arena->buildLosersCage();
+		parent::start();
 	}
 
 	public function tick() : void {
@@ -149,7 +147,6 @@ class StandOnColor extends Microgame implements Listener {
 	}
 
 	public function end() : void {
-		$this->hasEnded = true;
 		HandlerListManager::global()->unregisterAll($this);
 
 		$players = $this->arena->getPlayers();
@@ -185,6 +182,7 @@ class StandOnColor extends Microgame implements Listener {
 		foreach ($this->changedBlocks as $block) {
 			$this->arena->getWorld()->setBlock($block->getPosition(), $block, false);
 		}
+		parent::end();
 	}
 
 	public function getColor() : DyeColor {

--- a/src/LatamPMDevs/minerware/arena/microgame/normal/StandOnDiamond.php
+++ b/src/LatamPMDevs/minerware/arena/microgame/normal/StandOnDiamond.php
@@ -47,7 +47,6 @@ use function array_rand;
 use function array_reverse;
 use function asort;
 use function in_array;
-use function microtime;
 
 class StandOnDiamond extends Microgame implements Listener {
 
@@ -85,8 +84,6 @@ class StandOnDiamond extends Microgame implements Listener {
 	}
 
 	public function start() : void {
-		$this->startTime = microtime(true);
-		$this->hasStarted = true;
 		$this->plugin->getServer()->getPluginManager()->registerEvents($this, $this->plugin);
 
 		$map = $this->arena->getMap();
@@ -112,6 +109,7 @@ class StandOnDiamond extends Microgame implements Listener {
 		}
 		$this->arena->buildWinnersCage();
 		$this->arena->buildLosersCage();
+		parent::start();
 	}
 
 	public function tick() : void {
@@ -134,7 +132,6 @@ class StandOnDiamond extends Microgame implements Listener {
 	}
 
 	public function end() : void {
-		$this->hasEnded = true;
 		HandlerListManager::global()->unregisterAll($this);
 
 		$players = $this->arena->getPlayers();
@@ -161,6 +158,7 @@ class StandOnDiamond extends Microgame implements Listener {
 		foreach ($this->changedBlocks as $block) {
 			$this->arena->getWorld()->setBlock($block->getPosition(), $block, false);
 		}
+		parent::end();
 	}
 
 	public function isFloorBroken() : bool {

--- a/src/LatamPMDevs/minerware/event/MinerwareEvent.php
+++ b/src/LatamPMDevs/minerware/event/MinerwareEvent.php
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ *  ███╗   ███╗██╗███╗   ██╗███████╗██████╗ ██╗    ██╗ █████╗ ██████╗ ███████╗
+ *  ████╗ ████║██║████╗  ██║██╔════╝██╔══██╗██║    ██║██╔══██╗██╔══██╗██╔════╝
+ *  ██╔████╔██║██║██╔██╗ ██║█████╗  ██████╔╝██║ █╗ ██║███████║██████╔╝█████╗
+ *  ██║╚██╔╝██║██║██║╚██╗██║██╔══╝  ██╔══██╗██║███╗██║██╔══██║██╔══██╗██╔══╝
+ *  ██║ ╚═╝ ██║██║██║ ╚████║███████╗██║  ██║╚███╔███╔╝██║  ██║██║  ██║███████╗
+ *  ╚═╝     ╚═╝╚═╝╚═╝  ╚═══╝╚══════╝╚═╝  ╚═╝ ╚══╝╚══╝ ╚═╝  ╚═╝╚═╝  ╚═╝╚══════╝
+ *
+ * A game written in PHP for PocketMine-MP software.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Copyright 2022 © LatamPMDevs
+ */
+
+declare(strict_types=1);
+
+namespace LatamPMDevs\minerware\event;
+
+use pocketmine\event\Event;
+
+/**
+ * Minerware-only related events
+ */
+abstract class MinerwareEvent extends Event {
+}

--- a/src/LatamPMDevs/minerware/event/arena/ArenaChangeStatusEvent.php
+++ b/src/LatamPMDevs/minerware/event/arena/ArenaChangeStatusEvent.php
@@ -1,0 +1,52 @@
+<?php
+
+/**
+ *  ███╗   ███╗██╗███╗   ██╗███████╗██████╗ ██╗    ██╗ █████╗ ██████╗ ███████╗
+ *  ████╗ ████║██║████╗  ██║██╔════╝██╔══██╗██║    ██║██╔══██╗██╔══██╗██╔════╝
+ *  ██╔████╔██║██║██╔██╗ ██║█████╗  ██████╔╝██║ █╗ ██║███████║██████╔╝█████╗
+ *  ██║╚██╔╝██║██║██║╚██╗██║██╔══╝  ██╔══██╗██║███╗██║██╔══██║██╔══██╗██╔══╝
+ *  ██║ ╚═╝ ██║██║██║ ╚████║███████╗██║  ██║╚███╔███╔╝██║  ██║██║  ██║███████╗
+ *  ╚═╝     ╚═╝╚═╝╚═╝  ╚═══╝╚══════╝╚═╝  ╚═╝ ╚══╝╚══╝ ╚═╝  ╚═╝╚═╝  ╚═╝╚══════╝
+ *
+ * A game written in PHP for PocketMine-MP software.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Copyright 2022 © LatamPMDevs
+ */
+
+declare(strict_types=1);
+
+namespace LatamPMDevs\minerware\event\arena;
+
+use LatamPMDevs\minerware\arena\Arena;
+use LatamPMDevs\minerware\arena\Status;
+
+/**
+ * Called when an arena changes its status
+ */
+class ArenaChangeStatusEvent extends ArenaEvent {
+
+	public function __construct(
+		protected Status $oldStatus,
+		protected Status $newStatus,
+		Arena $arena
+	) {
+		parent::__construct($arena);
+	}
+
+	public function getOldStatus() : Status {
+		return $this->oldStatus;
+	}
+
+	public function getNewStatus() : Status {
+		return $this->newStatus;
+	}
+
+	public function setNewStatus(Status $status) : void {
+		$this->newStatus = $status;
+	}
+}

--- a/src/LatamPMDevs/minerware/event/arena/ArenaCreationEvent.php
+++ b/src/LatamPMDevs/minerware/event/arena/ArenaCreationEvent.php
@@ -1,0 +1,26 @@
+<?php
+
+/**
+ *  ███╗   ███╗██╗███╗   ██╗███████╗██████╗ ██╗    ██╗ █████╗ ██████╗ ███████╗
+ *  ████╗ ████║██║████╗  ██║██╔════╝██╔══██╗██║    ██║██╔══██╗██╔══██╗██╔════╝
+ *  ██╔████╔██║██║██╔██╗ ██║█████╗  ██████╔╝██║ █╗ ██║███████║██████╔╝█████╗
+ *  ██║╚██╔╝██║██║██║╚██╗██║██╔══╝  ██╔══██╗██║███╗██║██╔══██║██╔══██╗██╔══╝
+ *  ██║ ╚═╝ ██║██║██║ ╚████║███████╗██║  ██║╚███╔███╔╝██║  ██║██║  ██║███████╗
+ *  ╚═╝     ╚═╝╚═╝╚═╝  ╚═══╝╚══════╝╚═╝  ╚═╝ ╚══╝╚══╝ ╚═╝  ╚═╝╚═╝  ╚═╝╚══════╝
+ *
+ * A game written in PHP for PocketMine-MP software.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Copyright 2022 © LatamPMDevs
+ */
+
+declare(strict_types=1);
+
+namespace LatamPMDevs\minerware\event\arena;
+
+class ArenaCreationEvent extends ArenaEvent {
+}

--- a/src/LatamPMDevs/minerware/event/arena/ArenaEndEvent.php
+++ b/src/LatamPMDevs/minerware/event/arena/ArenaEndEvent.php
@@ -1,0 +1,26 @@
+<?php
+
+/**
+ *  ███╗   ███╗██╗███╗   ██╗███████╗██████╗ ██╗    ██╗ █████╗ ██████╗ ███████╗
+ *  ████╗ ████║██║████╗  ██║██╔════╝██╔══██╗██║    ██║██╔══██╗██╔══██╗██╔════╝
+ *  ██╔████╔██║██║██╔██╗ ██║█████╗  ██████╔╝██║ █╗ ██║███████║██████╔╝█████╗
+ *  ██║╚██╔╝██║██║██║╚██╗██║██╔══╝  ██╔══██╗██║███╗██║██╔══██║██╔══██╗██╔══╝
+ *  ██║ ╚═╝ ██║██║██║ ╚████║███████╗██║  ██║╚███╔███╔╝██║  ██║██║  ██║███████╗
+ *  ╚═╝     ╚═╝╚═╝╚═╝  ╚═══╝╚══════╝╚═╝  ╚═╝ ╚══╝╚══╝ ╚═╝  ╚═╝╚═╝  ╚═╝╚══════╝
+ *
+ * A game written in PHP for PocketMine-MP software.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Copyright 2022 © LatamPMDevs
+ */
+
+declare(strict_types=1);
+
+namespace LatamPMDevs\minerware\event\arena;
+
+class ArenaEndEvent extends ArenaEvent {
+}

--- a/src/LatamPMDevs/minerware/event/arena/ArenaEvent.php
+++ b/src/LatamPMDevs/minerware/event/arena/ArenaEvent.php
@@ -1,0 +1,39 @@
+<?php
+
+/**
+ *  ███╗   ███╗██╗███╗   ██╗███████╗██████╗ ██╗    ██╗ █████╗ ██████╗ ███████╗
+ *  ████╗ ████║██║████╗  ██║██╔════╝██╔══██╗██║    ██║██╔══██╗██╔══██╗██╔════╝
+ *  ██╔████╔██║██║██╔██╗ ██║█████╗  ██████╔╝██║ █╗ ██║███████║██████╔╝█████╗
+ *  ██║╚██╔╝██║██║██║╚██╗██║██╔══╝  ██╔══██╗██║███╗██║██╔══██║██╔══██╗██╔══╝
+ *  ██║ ╚═╝ ██║██║██║ ╚████║███████╗██║  ██║╚███╔███╔╝██║  ██║██║  ██║███████╗
+ *  ╚═╝     ╚═╝╚═╝╚═╝  ╚═══╝╚══════╝╚═╝  ╚═╝ ╚══╝╚══╝ ╚═╝  ╚═╝╚═╝  ╚═╝╚══════╝
+ *
+ * A game written in PHP for PocketMine-MP software.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Copyright 2022 © LatamPMDevs
+ */
+
+declare(strict_types=1);
+
+namespace LatamPMDevs\minerware\event\arena;
+
+use LatamPMDevs\minerware\arena\Arena;
+use LatamPMDevs\minerware\event\MinerwareEvent;
+
+/**
+ * Arena-only related events
+ */
+abstract class ArenaEvent extends MinerwareEvent {
+
+	public function __construct(protected Arena $arena) {
+	}
+
+	public function getArena() : Arena {
+		return $this->arena;
+	}
+}

--- a/src/LatamPMDevs/minerware/event/arena/PlayerJoinArenaEvent.php
+++ b/src/LatamPMDevs/minerware/event/arena/PlayerJoinArenaEvent.php
@@ -23,13 +23,14 @@ declare(strict_types=1);
 namespace LatamPMDevs\minerware\event\arena;
 
 use LatamPMDevs\minerware\arena\Arena;
+use pocketmine\event\Cancellable;
 use pocketmine\event\CancellableTrait;
 use pocketmine\player\Player;
 
 /**
  * Called when a player joins an arena
  */
-class PlayerJoinArenaEvent extends ArenaEvent {
+class PlayerJoinArenaEvent extends ArenaEvent implements Cancellable {
 	use CancellableTrait;
 
 	public function __construct(protected Player $player, Arena $arena) {

--- a/src/LatamPMDevs/minerware/event/arena/PlayerJoinArenaEvent.php
+++ b/src/LatamPMDevs/minerware/event/arena/PlayerJoinArenaEvent.php
@@ -23,7 +23,6 @@ declare(strict_types=1);
 namespace LatamPMDevs\minerware\event\arena;
 
 use LatamPMDevs\minerware\arena\Arena;
-use pocketmine\event\Cancellable;
 use pocketmine\event\CancellableTrait;
 use pocketmine\player\Player;
 

--- a/src/LatamPMDevs/minerware/event/arena/PlayerJoinArenaEvent.php
+++ b/src/LatamPMDevs/minerware/event/arena/PlayerJoinArenaEvent.php
@@ -1,0 +1,43 @@
+<?php
+
+/**
+ *  ███╗   ███╗██╗███╗   ██╗███████╗██████╗ ██╗    ██╗ █████╗ ██████╗ ███████╗
+ *  ████╗ ████║██║████╗  ██║██╔════╝██╔══██╗██║    ██║██╔══██╗██╔══██╗██╔════╝
+ *  ██╔████╔██║██║██╔██╗ ██║█████╗  ██████╔╝██║ █╗ ██║███████║██████╔╝█████╗
+ *  ██║╚██╔╝██║██║██║╚██╗██║██╔══╝  ██╔══██╗██║███╗██║██╔══██║██╔══██╗██╔══╝
+ *  ██║ ╚═╝ ██║██║██║ ╚████║███████╗██║  ██║╚███╔███╔╝██║  ██║██║  ██║███████╗
+ *  ╚═╝     ╚═╝╚═╝╚═╝  ╚═══╝╚══════╝╚═╝  ╚═╝ ╚══╝╚══╝ ╚═╝  ╚═╝╚═╝  ╚═╝╚══════╝
+ *
+ * A game written in PHP for PocketMine-MP software.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Copyright 2022 © LatamPMDevs
+ */
+
+declare(strict_types=1);
+
+namespace LatamPMDevs\minerware\event\arena;
+
+use LatamPMDevs\minerware\arena\Arena;
+use pocketmine\event\Cancellable;
+use pocketmine\event\CancellableTrait;
+use pocketmine\player\Player;
+
+/**
+ * Called when a player joins an arena
+ */
+class PlayerJoinArenaEvent extends ArenaEvent {
+	use CancellableTrait;
+
+	public function __construct(protected Player $player, Arena $arena) {
+		parent::__construct($arena);
+	}
+
+	public function getPlayer() : Player {
+		return $this->player;
+	}
+}

--- a/src/LatamPMDevs/minerware/event/arena/microgame/MicrogameEndEvent.php
+++ b/src/LatamPMDevs/minerware/event/arena/microgame/MicrogameEndEvent.php
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ *  ███╗   ███╗██╗███╗   ██╗███████╗██████╗ ██╗    ██╗ █████╗ ██████╗ ███████╗
+ *  ████╗ ████║██║████╗  ██║██╔════╝██╔══██╗██║    ██║██╔══██╗██╔══██╗██╔════╝
+ *  ██╔████╔██║██║██╔██╗ ██║█████╗  ██████╔╝██║ █╗ ██║███████║██████╔╝█████╗
+ *  ██║╚██╔╝██║██║██║╚██╗██║██╔══╝  ██╔══██╗██║███╗██║██╔══██║██╔══██╗██╔══╝
+ *  ██║ ╚═╝ ██║██║██║ ╚████║███████╗██║  ██║╚███╔███╔╝██║  ██║██║  ██║███████╗
+ *  ╚═╝     ╚═╝╚═╝╚═╝  ╚═══╝╚══════╝╚═╝  ╚═╝ ╚══╝╚══╝ ╚═╝  ╚═╝╚═╝  ╚═╝╚══════╝
+ *
+ * A game written in PHP for PocketMine-MP software.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Copyright 2022 © LatamPMDevs
+ */
+
+declare(strict_types=1);
+
+namespace LatamPMDevs\minerware\event\arena\microgame;
+
+/**
+ * Called when a microgame ends
+ */
+class MicrogameEndEvent extends MicrogameEvent {
+}

--- a/src/LatamPMDevs/minerware/event/arena/microgame/MicrogameEvent.php
+++ b/src/LatamPMDevs/minerware/event/arena/microgame/MicrogameEvent.php
@@ -23,7 +23,7 @@ declare(strict_types=1);
 namespace LatamPMDevs\minerware\event\arena\microgame;
 
 use LatamPMDevs\minerware\arena\microgame\Microgame;
-use LatamPMDevs\minerware\event\ArenaEvent;
+use LatamPMDevs\minerware\event\arena\ArenaEvent;
 
 /**
  * Microgame-only related events

--- a/src/LatamPMDevs/minerware/event/arena/microgame/MicrogameEvent.php
+++ b/src/LatamPMDevs/minerware/event/arena/microgame/MicrogameEvent.php
@@ -1,0 +1,40 @@
+<?php
+
+/**
+ *  ███╗   ███╗██╗███╗   ██╗███████╗██████╗ ██╗    ██╗ █████╗ ██████╗ ███████╗
+ *  ████╗ ████║██║████╗  ██║██╔════╝██╔══██╗██║    ██║██╔══██╗██╔══██╗██╔════╝
+ *  ██╔████╔██║██║██╔██╗ ██║█████╗  ██████╔╝██║ █╗ ██║███████║██████╔╝█████╗
+ *  ██║╚██╔╝██║██║██║╚██╗██║██╔══╝  ██╔══██╗██║███╗██║██╔══██║██╔══██╗██╔══╝
+ *  ██║ ╚═╝ ██║██║██║ ╚████║███████╗██║  ██║╚███╔███╔╝██║  ██║██║  ██║███████╗
+ *  ╚═╝     ╚═╝╚═╝╚═╝  ╚═══╝╚══════╝╚═╝  ╚═╝ ╚══╝╚══╝ ╚═╝  ╚═╝╚═╝  ╚═╝╚══════╝
+ *
+ * A game written in PHP for PocketMine-MP software.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Copyright 2022 © LatamPMDevs
+ */
+
+declare(strict_types=1);
+
+namespace LatamPMDevs\minerware\event\arena\microgame;
+
+use LatamPMDevs\minerware\arena\microgame\Microgame;
+use LatamPMDevs\minerware\event\ArenaEvent;
+
+/**
+ * Microgame-only related events
+ */
+abstract class MicrogameEvent extends ArenaEvent {
+
+	public function __construct(protected Microgame $microgame) {
+		parent::__construct($microgame->getArena());
+	}
+
+	public function getMicrogame() : Microgame {
+		return $this->microgame;
+	}
+}

--- a/src/LatamPMDevs/minerware/event/arena/microgame/MicrogameStartEvent.php
+++ b/src/LatamPMDevs/minerware/event/arena/microgame/MicrogameStartEvent.php
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ *  ███╗   ███╗██╗███╗   ██╗███████╗██████╗ ██╗    ██╗ █████╗ ██████╗ ███████╗
+ *  ████╗ ████║██║████╗  ██║██╔════╝██╔══██╗██║    ██║██╔══██╗██╔══██╗██╔════╝
+ *  ██╔████╔██║██║██╔██╗ ██║█████╗  ██████╔╝██║ █╗ ██║███████║██████╔╝█████╗
+ *  ██║╚██╔╝██║██║██║╚██╗██║██╔══╝  ██╔══██╗██║███╗██║██╔══██║██╔══██╗██╔══╝
+ *  ██║ ╚═╝ ██║██║██║ ╚████║███████╗██║  ██║╚███╔███╔╝██║  ██║██║  ██║███████╗
+ *  ╚═╝     ╚═╝╚═╝╚═╝  ╚═══╝╚══════╝╚═╝  ╚═╝ ╚══╝╚══╝ ╚═╝  ╚═╝╚═╝  ╚═╝╚══════╝
+ *
+ * A game written in PHP for PocketMine-MP software.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Copyright 2022 © LatamPMDevs
+ */
+
+declare(strict_types=1);
+
+namespace LatamPMDevs\minerware\event\arena\microgame;
+
+/**
+ * Called when a microgame starts
+ */
+class MicrogameStartEvent extends MicrogameEvent {
+}

--- a/src/LatamPMDevs/minerware/event/arena/microgame/PlayerMicrogameLoseEvent.php
+++ b/src/LatamPMDevs/minerware/event/arena/microgame/PlayerMicrogameLoseEvent.php
@@ -1,0 +1,39 @@
+<?php
+
+/**
+ *  ███╗   ███╗██╗███╗   ██╗███████╗██████╗ ██╗    ██╗ █████╗ ██████╗ ███████╗
+ *  ████╗ ████║██║████╗  ██║██╔════╝██╔══██╗██║    ██║██╔══██╗██╔══██╗██╔════╝
+ *  ██╔████╔██║██║██╔██╗ ██║█████╗  ██████╔╝██║ █╗ ██║███████║██████╔╝█████╗
+ *  ██║╚██╔╝██║██║██║╚██╗██║██╔══╝  ██╔══██╗██║███╗██║██╔══██║██╔══██╗██╔══╝
+ *  ██║ ╚═╝ ██║██║██║ ╚████║███████╗██║  ██║╚███╔███╔╝██║  ██║██║  ██║███████╗
+ *  ╚═╝     ╚═╝╚═╝╚═╝  ╚═══╝╚══════╝╚═╝  ╚═╝ ╚══╝╚══╝ ╚═╝  ╚═╝╚═╝  ╚═╝╚══════╝
+ *
+ * A game written in PHP for PocketMine-MP software.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Copyright 2022 © LatamPMDevs
+ */
+
+declare(strict_types=1);
+
+namespace LatamPMDevs\minerware\event\arena\microgame;
+
+use LatamPMDevs\minerware\arena\microgame\Microgame;
+
+/**
+ * Called when a player loses a microgame
+ */
+class PlayerMicrogameLoseEvent extends MicrogameEvent {
+
+	public function __construct(protected Player $player, Microgame $microgame) {
+		parent::__construct($microgame);
+	}
+
+	public function getPlayer() : Player {
+		return $this->player;
+	}
+}

--- a/src/LatamPMDevs/minerware/event/arena/microgame/PlayerMicrogameLoseEvent.php
+++ b/src/LatamPMDevs/minerware/event/arena/microgame/PlayerMicrogameLoseEvent.php
@@ -23,6 +23,7 @@ declare(strict_types=1);
 namespace LatamPMDevs\minerware\event\arena\microgame;
 
 use LatamPMDevs\minerware\arena\microgame\Microgame;
+use pocketmine\player\Player;
 
 /**
  * Called when a player loses a microgame

--- a/src/LatamPMDevs/minerware/event/arena/microgame/PlayerMicrogameWinEvent.php
+++ b/src/LatamPMDevs/minerware/event/arena/microgame/PlayerMicrogameWinEvent.php
@@ -1,0 +1,39 @@
+<?php
+
+/**
+ *  ███╗   ███╗██╗███╗   ██╗███████╗██████╗ ██╗    ██╗ █████╗ ██████╗ ███████╗
+ *  ████╗ ████║██║████╗  ██║██╔════╝██╔══██╗██║    ██║██╔══██╗██╔══██╗██╔════╝
+ *  ██╔████╔██║██║██╔██╗ ██║█████╗  ██████╔╝██║ █╗ ██║███████║██████╔╝█████╗
+ *  ██║╚██╔╝██║██║██║╚██╗██║██╔══╝  ██╔══██╗██║███╗██║██╔══██║██╔══██╗██╔══╝
+ *  ██║ ╚═╝ ██║██║██║ ╚████║███████╗██║  ██║╚███╔███╔╝██║  ██║██║  ██║███████╗
+ *  ╚═╝     ╚═╝╚═╝╚═╝  ╚═══╝╚══════╝╚═╝  ╚═╝ ╚══╝╚══╝ ╚═╝  ╚═╝╚═╝  ╚═╝╚══════╝
+ *
+ * A game written in PHP for PocketMine-MP software.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Copyright 2022 © LatamPMDevs
+ */
+
+declare(strict_types=1);
+
+namespace LatamPMDevs\minerware\event\arena\microgame;
+
+use LatamPMDevs\minerware\arena\microgame\Microgame;
+
+/**
+ * Called when a player wins a microgame
+ */
+class PlayerMicrogameWinEvent extends MicrogameEvent {
+
+	public function __construct(protected Player $player, Microgame $microgame) {
+		parent::__construct($microgame);
+	}
+
+	public function getPlayer() : Player {
+		return $this->player;
+	}
+}

--- a/src/LatamPMDevs/minerware/event/arena/microgame/PlayerMicrogameWinEvent.php
+++ b/src/LatamPMDevs/minerware/event/arena/microgame/PlayerMicrogameWinEvent.php
@@ -23,6 +23,7 @@ declare(strict_types=1);
 namespace LatamPMDevs\minerware\event\arena\microgame;
 
 use LatamPMDevs\minerware\arena\microgame\Microgame;
+use pocketmine\player\Player;
 
 /**
  * Called when a player wins a microgame


### PR DESCRIPTION
This PR implements an Events API, which can be used for example to monitor player statistics (as mentioned in #42) or by external plugins.